### PR TITLE
Mesh device compatible version

### DIFF
--- a/src/Encoder.h
+++ b/src/Encoder.h
@@ -32,9 +32,16 @@
 #include "Particle.h"
 
 #define IO_REG_TYPE                     uint32_t
-#define PIN_TO_BASEREG(pin)             (&(HAL_Pin_Map()[pin].gpio_peripheral->IDR))
-#define PIN_TO_BITMASK(pin)             (HAL_Pin_Map()[pin].gpio_pin)
-#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+
+#if defined(HAL_PLATFORM_NRF52840) && HAL_PLATFORM_NRF52840
+# define PIN_TO_BASEREG(pin)             (0)
+# define PIN_TO_BITMASK(pin)             (pin)
+# define DIRECT_PIN_READ(base, mask)     pinReadFast(mask)
+#else
+# define PIN_TO_BASEREG(pin)             (&(HAL_Pin_Map()[pin].gpio_peripheral->IDR))
+# define PIN_TO_BITMASK(pin)             (HAL_Pin_Map()[pin].gpio_pin)
+# define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+#endif
 
 class Encoder
 {


### PR DESCRIPTION
Tested in Argon and Photon with an actual rotary encoded and the basic test works.

Compiles:
Photon 0.6.3, 0.7.0, 0.8.0-rc.11
Electron 0.7.0
Argon 0.8.0-rc.25
Boron 0.8.0-rc.25
Xenon 0.8.0-rc.25
